### PR TITLE
Feature/GitHub templates

### DIFF
--- a/.github/templates/bug.md
+++ b/.github/templates/bug.md
@@ -1,0 +1,25 @@
+<!-- Please search existing issues to avoid creating duplicates. -->
+# Bug Report
+
+Bug: Not so Awesome Bug Title
+
+## Description
+
+Info about the bug goes here.
+
+### Steps to Reproduce
+
+1. Step 1
+2. Step 2
+
+### Expected Result
+
+The expected result was...
+
+You may write the expected result or add a screenshot.
+
+### Actual Results
+
+The actual result was...
+
+Would be awesome to link screenshots here and/or error messages received.

--- a/.github/templates/giga-task.md
+++ b/.github/templates/giga-task.md
@@ -1,0 +1,14 @@
+<!-- Issue title should mirror the Epic Title. -->
+# Epic Title
+
+Feature: Awesome Feature Title
+
+## Epic Description
+
+This Feature will...
+
+<!-- Substitute taskIDs for real task ids -->
+## List of Tasks (Complete in order)
+
+1. [ ] [Task 1: Awesome Task Title](https://github.com/raswonders/sticky-notes/issues/taskID)
+2. [ ] [Task 2: Awesome Task Title](https://github.com/raswonders/sticky-notes/issues/taskID)

--- a/.github/templates/pull-request.md
+++ b/.github/templates/pull-request.md
@@ -1,0 +1,18 @@
+# Story Title
+
+<!-- Substitute taskID with real task id -->
+[This is the Task Title](https://github.com/raswonders/sticky-notes/issues/taskID)
+
+## Changes made
+
+- made this
+- did that
+
+## How does the solution address the problem
+
+This PR will...
+
+## Linked issues
+
+<!-- Substitute taskID with real task id -->
+Resolves #taskID

--- a/.github/templates/task.md
+++ b/.github/templates/task.md
@@ -1,0 +1,13 @@
+<!-- Issue title should mirror the Task Title. -->
+# Task Title
+
+Task: Awesome Task Title
+
+## Task Description
+
+This Task will...
+
+<!-- Substitute taskID for existing task id -->
+## Epic Parent
+
+[Feature: Awesome Feature Title](https://github.com/raswonders/sticky-notes/issues/taskID)


### PR DESCRIPTION
# Story Title

<!-- Substitute taskID with real task id -->
[Task: create github issue templates](https://github.com/raswonders/sticky-notes/issues/7)

## Changes made

Created github templates for common project primitives (Task, GigaTask, Bug, PR)

## How does the solution address the problem

Templates will make it easier to share what was being done and why

## Linked issues

<!-- Substitute taskID with real task id -->
Resolves #7