### PR TITLE
prevent creation of note on edit

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,9 +2,10 @@ import "./style.css";
 import { addNote, removeNote } from "./src/components/note";
 
 window.addEventListener("click", (event) => {
+  if (event.target.classList.contains("note-text")) return;
   if (event.target.classList.contains("note-deleter")) {
     removeNote(event.target.parentElement);
-  } else {
-    addNote();
+    return;
   }
+  addNote();
 });


### PR DESCRIPTION
# Story Title

<!-- Substitute taskID with real task id -->
[Task: Edit Sticky Notes#12](https://github.com/raswonders/sticky-notes/issues/12)

## Changes made

Made it so click handler on window won't create another note if user clicks to edit note.

## Linked issues

<!-- Substitute taskID with real task id -->
Resolves #12