### PR TITLE
set endings via formatter as crlf

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "printWidth": 80,
   "tabWidth": 2,
-  "semi": true
+  "semi": true,
+  "endOfLine": "crlf"
 }


### PR DESCRIPTION
# Story Title

<!-- Substitute taskID with real task id -->
[Bug: code formatter sets ends of lines as LF#20](https://github.com/raswonders/sticky-notes/issues/20)

## How does the solution address the problem

Formatter sets line endings as CRLF. 

## Linked issues

<!-- Substitute taskID with real task id -->
Resolves #20