### PR TITLE
move note to front right after its created

### DIFF
--- a/src/components/note.js
+++ b/src/components/note.js
@@ -2,6 +2,7 @@ import "./note.css";
 import { dragElement } from "../utils";
 import { saveSession } from "../session";
 import { headerHeight } from "../utils";
+import { moveNoteToFront } from "../utils";
 
 window.addEventListener("beforeunload", saveSession);
 
@@ -22,7 +23,9 @@ export function createNote(x, y, offset = true) {
 }
 
 export function addNote(x, y) {
-  document.querySelector(".note-gallery").appendChild(createNote(x, y));
+  const newNote = createNote(x, y);
+  moveNoteToFront(newNote);
+  document.querySelector(".note-gallery").appendChild(newNote);
 }
 
 export function removeNote(note) {


### PR DESCRIPTION
# Story Title

<!-- Substitute taskID with real task id -->
[Bug: newly created notes can spawn below preexistent notes#49](https://github.com/raswonders/sticky-notes/issues/49)

## Changes made

- moved note to front right after it has been created

## Linked issues

<!-- Substitute taskID with real task id -->
Resolves #49